### PR TITLE
Readme fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Neural Networks in `ruby`
 ![NN eye candy](ruby-fann.png)
 
 
-RubyFann, or "ruby-fann" is a Ruby Gem (no Rails required) that binds to FANN (Fast Artificial Neural Network) from within a ruby/rails environment.  FANN is a is a free native open source neural network library, which implements multilayer artificial neural networks, supporting both fully-connected and sparsely-connected networks.  It is easy to use, versatile, well documented, and fast.  `RubyFann` makes working with neural networks a breeze using `ruby`, with the added benefit that most of the heavy lifting is done natively.
+RubyFann, or "ruby-fann" is a Ruby Gem (no Rails required) that binds to FANN (Fast Artificial Neural Network) from within a Ruby/Rails environment.  FANN is a free, native, and open source neural network library, which implements multilayer artificial neural networks, supporting both fully-connected and sparsely-connected networks.  It is easy to use, versatile, well documented, and fast.  `RubyFann` makes working with neural networks a breeze using Ruby, with the added benefit that most of the heavy lifting is done natively.
 
 A talk given by our friend Ethan from Big-Oh Studios at Lone Star Ruby 2013: http://confreaks.com/videos/2609-lonestarruby2013-neural-networks-with-rubyfann
 


### PR DESCRIPTION
Noticed a few things in the readme to fixup quick:

-  inconsistent use of ruby, `ruby`, and Ruby
- "FANN is a is a free" typo
- "free native open source neural network library" is a mouthful of words without some commas

🎸 